### PR TITLE
Refactored the API to use GET and POST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 
 # Mac files
 .DS_Store
+
 db/
+*.pyc
 
 README.pdf
 *.pdf

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -4,7 +4,8 @@ drop table if exists links;
 CREATE TABLE `nodes` (
     `id` INTEGER PRIMARY KEY AUTOINCREMENT,
     `contents` VARCHAR(300),
-    `renderer` VARCHAR(50)
+    `renderer` VARCHAR(50),
+    `children` TEXT
 );
 CREATE TABLE `links` (
     `origin` INTEGER NOT NULL,

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -40600,12 +40600,12 @@ function overwriteNode(node) {
   });
 }
 
-function overwriteChildren(node, create) {
-  var endpoint = mainUrl + ('/children/' + node.id + '/');
+function overwriteChildren(node) {
+  var endpoint = mainUrl + ('/node/update/' + node.id + '/');
   // Passing in '' as an argument will default to whatever the original value was
   var data = { contents: '', renderer: '', children: JSON.stringify(node.children) };
   return _jquery2['default'].ajax(endpoint, {
-    method: create ? "POST" : "POST",
+    method: "POST",
     data: data,
     dataType: "json"
   });
@@ -40654,9 +40654,8 @@ function addNewChild(node, tag, markdown, renderer, callback) {
     data.children = {};
 
     initialized_child = new _ModelsNodeJs2['default'](data);
-    var create = Object.keys(node.children).length === 0;
     node.children[tag] = initialized_child.id;
-    return overwriteChildren(node, create);
+    return overwriteChildren(node);
   }, function (jqXHR, textStatus, errorThrown) {
     console.error(textStatus);
     throw errorThrown;

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -40584,7 +40584,7 @@ var _ModelsNodeJs2 = _interopRequireDefault(_ModelsNodeJs);
 var mainUrl = "";
 
 function getNode(nodeId) {
-  var endpoint = mainUrl + ('/node/' + nodeId + '/');
+  var endpoint = mainUrl + ('/node/get/' + nodeId + '/');
   return _jquery2['default'].ajax(endpoint, {
     method: "GET",
     dataType: "json"
@@ -40592,7 +40592,7 @@ function getNode(nodeId) {
 }
 
 function overwriteNode(node) {
-  var endpoint = mainUrl + ('/node/' + node.id + '/');
+  var endpoint = mainUrl + ('/node/update/' + node.id + '/');
   return _jquery2['default'].ajax(endpoint, {
     method: "POST",
     data: node,
@@ -40602,9 +40602,10 @@ function overwriteNode(node) {
 
 function overwriteChildren(node, create) {
   var endpoint = mainUrl + ('/children/' + node.id + '/');
-  var data = { children: JSON.stringify(node.children) };
+  // Passing in '' as an argument will default to whatever the original value was
+  var data = { contents: '', renderer: '', children: JSON.stringify(node.children) };
   return _jquery2['default'].ajax(endpoint, {
-    method: create ? "PUT" : "POST",
+    method: create ? "POST" : "POST",
     data: data,
     dataType: "json"
   });
@@ -40612,9 +40613,9 @@ function overwriteChildren(node, create) {
 
 function createNode(node) {
   //mock for creation process
-  var endpoint = mainUrl + "/node/";
+  var endpoint = mainUrl + "/node/add/";
   return _jquery2['default'].ajax(endpoint, {
-    method: "PUT",
+    method: "POST",
     data: node,
     dataType: "json"
   });

--- a/frontend/src/utils/webapi.js
+++ b/frontend/src/utils/webapi.js
@@ -19,7 +19,7 @@ function getNode(nodeId: string){
 }
 
 function overwriteNode(node: Node){
-  let endpoint = mainUrl + `/node/${node.id}/`;
+  let endpoint = mainUrl + `/node/update/${node.id}/`;
   return $.ajax(endpoint, {
     method: "POST",
     data: node,
@@ -27,20 +27,20 @@ function overwriteNode(node: Node){
   });
 }
 
-function overwriteChildren(node: Node, create: boolean){
-  let endpoint = mainUrl + `/children/${node.id}/`;
+function overwriteChildren(node: Node){
+  let endpoint = mainUrl + `/node/update/${node.id}/`;
   let data = {children: JSON.stringify(node.children)};
   return $.ajax(endpoint, {
-    method: create ? "PUT" : "POST",
+    method: "POST",
     data: data,
     dataType: "json"
   })
 }
 
 function createNode(node: Node){ //mock for creation process
-  let endpoint = mainUrl + "/node/";
+  let endpoint = mainUrl + "/node/add/";
   return $.ajax(endpoint, {
-    method: "PUT",
+    method: "POST",
     data: node,
     dataType: "json"
   });
@@ -75,9 +75,8 @@ export function addNewChild(node: Node, tag: string, markdown: string, renderer:
       data.children = {};
 
       initialized_child = new Node(data);
-      let create = Object.keys(node.children).length === 0;
       node.children[tag] = initialized_child.id;
-      return overwriteChildren(node, create);
+      return overwriteChildren(node);
     }, (jqXHR, textStatus, errorThrown) => {
       console.error(textStatus);
       throw errorThrown;

--- a/rpc_specification.md
+++ b/rpc_specification.md
@@ -13,8 +13,8 @@ Nodes
 
 ### Adding a node
 
- - end point: `/node/`
- - request: HTTP PUT
+ - end point: `/node/add/`
+ - request: HTTP POST
  - data (input):
 ```
 {
@@ -29,11 +29,11 @@ Nodes
   "id": 1
 }
 ```
- - Node ID will be auto-assigned (monotonically increasing)
+ - Node ID will be auto-assigned (constantly increasing)
 
 ### Accessing a node
 
- - end point: `/node/<id>/` where `<id>` is some integer
+ - end point: `/node/get/<id>/` where `<id>` is some integer
  - request: HTTP GET
  - data (input): none
  - return data:
@@ -48,9 +48,9 @@ Nodes
  - No two nodes can have the same ID
  - If you request a non-existent node, you get an exception
 
-### Editing a node
+### Editing/Updating a node
 
- - end point: `/node/<id>/` where `<id>` is some integer
+ - end point: `/node/update/<id>/` where `<id>` is some integer
  - request: HTTP POST
  - data (input):
 ```
@@ -80,39 +80,11 @@ Children
 
 ### Adding children
 
- - end point: `/children/<id>/` where `id` is the parent's id
- - request: HTTP PUT
- - data (input):
-```
-{
-  "children": "7",
-}
-```
- - return data:
-```
-{
-  "message": "Children were successfully added to the node",
-  "id": "4"
-}
-```
+ - Please see "Editing a node"
 
 ### Editing a node's children
 
- - end point: `/children/<id>/` where `id` is the parent's id
- - request: HTTP POST
- - data (input):
-```
-{
-  "children": "7",
-}
-```
- - return data:
-```
-{
-  "message": "Children were successfully updated.",
-  "id": "4"
-}
-```
+ - Please see "Editing a node"
 
 Tree
 ----


### PR DESCRIPTION
I refactored the API to use GET and POST, instead of PUT. I also updated the database structure to not use the `links` OR `children` databases (the `nodes` database holds all this information now).

Adding/editing children can now be done by updating the parent node.

Lastly, I updated the frontend to interface with the new changes in backend structure, so the overwriteChildren method will now update the node. This should probably be changed to just use the "update node" method (if one such method exists).

Note: for the update node call, passing in `""` (empty string) as any value will default the field to its previous value. The initial value for no children is `"{}"` (string denoting empty JSON).

This implementation has the issue that we cannot overwrite an old value to the empty string (so we can't ever get rid of something's contents, for example). Not sure if there's a better work around.
