### PR TITLE
Implemented node deletion and root viewing/setting/deletion

### DIFF
--- a/backend/addSampleData.py
+++ b/backend/addSampleData.py
@@ -40,6 +40,12 @@ def update_node(node_id, contents='', renderer='', children=''):
     ret = post(os.path.join(URL, 'node/update', node_id, ''), data=node_value)
     return ret
 
+def delete_node(node_id):
+    """Uses the backend API to delete a node that already exists"""
+    node_id = str(node_id)
+    ret = post(os.path.join(URL, 'node/delete', node_id, ''), data={})
+    return ret
+
 ## @private
 def node_compare(node1, node2):
     id1 = int(node1['id'])

--- a/backend/cdApp.py
+++ b/backend/cdApp.py
@@ -158,6 +158,34 @@ class Tree(Resource):
         except Exception:
             raise InvalidUsage('Unable to find the tree', status_code=500)
 
+class Root(Resource):
+    def post(self, course_id, operation, root_id):
+        if operation == 'set':
+            g.db.execute('''UPDATE nodes 
+                            SET isroot=1 
+                            WHERE id=%s AND course_id=%s AND isalive=1''' % (root_id, course_id))
+            g.db.commit()
+            return jsonify(message='Successfully labeled node as a root.', id=root_id)
+        elif operation == 'delete':
+            g.db.execute('''UPDATE nodes 
+                            SET isroot=0 
+                            WHERE id=%s AND course_id=%s AND isalive=1''' % (root_id, course_id))
+            g.db.commit()
+            return jsonify(message='Successfully removed root label.', id=root_id)
+        else:
+            raise InvalidUsage('Unknown operation type')
+
+    def get(self, course_id, operation):
+        if operation != 'get':
+            raise InvalidUsage('Unknown operation type')
+
+        cursor = g.db.execute('''SELECT id, renderer 
+                              FROM nodes
+                              WHERE course_id = %s AND isalive=1 AND isroot=1''' % course_id)
+        root_list = cursor.fetchall()
+        return root_list
+
+
 # @deprecated
 # class Link(Resource):
 #     def post(self):
@@ -190,6 +218,7 @@ api.add_resource(Node, '/<course_id>/node/<operation>/', '/<course_id>/node/<ope
 # api.add_resource(Children, '/children/<operation>/<node_id>/')
 api.add_resource(Tree, '/<course_id>/tree/')
 # api.add_resource(Link, '/link/')
+api.add_resource(Root, '/<course_id>/root/<operation>/', '/<course_id>/root/<operation>/<root_id>/')
 
 # @app.route('/addNode', methods=['POST'])
 

--- a/backend/cdApp.py
+++ b/backend/cdApp.py
@@ -68,12 +68,12 @@ class Node(Resource):
         """
         if operation == 'add':
             DEFAULT_CHILDREN = '{}'
-            g.db.execute('INSERT INTO nodes (contents, renderer, children, course_id) VALUES(?, ?, ?, ?)',
-                         [request.form['contents'], request.form['renderer'], DEFAULT_CHILDREN, course_id])
-            cursor = g.db.execute('SELECT id FROM nodes WHERE course_id=%s ORDER BY id DESC limit 1' % course_id)
+            g.db.execute('INSERT INTO nodes (contents, renderer, children, course_id, isalive) VALUES(?, ?, ?, ?, ?)',
+                         [request.form['contents'], request.form['renderer'], DEFAULT_CHILDREN, course_id, 1])
+            cursor = g.db.execute('SELECT id FROM nodes WHERE course_id=%s AND isalive=1 ORDER BY id DESC limit 1' % course_id)
             g.db.commit()
-            ret_id = cursor.fetchone()
-            return jsonify(message='New node was successfully created', id=ret_id['id'])
+            added_node = cursor.fetchone()
+            return jsonify(message='New node was successfully created', id=added_node['id'])
         elif operation == 'update':
             try:
                 node_id = str(node_id)
@@ -82,13 +82,19 @@ class Node(Resource):
                 children = request.form['children']
                 g.db.execute('''UPDATE nodes 
                                 SET contents=(?),renderer=(?),children=(?) 
-                                WHERE id=%s AND course_id=%s''' % (node_id, course_id),
+                                WHERE id=%s AND course_id=%s AND isalive=1''' % (node_id, course_id),
                              [contents, renderer, children])
             except Exception as e:
                 print str(e)
                 raise InvalidUsage('Internal error', status_code=500)
             g.db.commit()
             return jsonify(message='Node was successfully updated.', id=node_id)
+        elif operation == 'delete':
+            g.db.execute('''UPDATE nodes 
+                            SET isalive=0 
+                            WHERE id=%s AND course_id=%s''' % (node_id, course_id))
+            g.db.commit()
+            return jsonify(message='Node was successfully deleted.', id=node_id)
         else:
             raise InvalidUsage('Unknown operation type')
 
@@ -104,7 +110,7 @@ class Node(Resource):
         node_id = str(node_id)
         cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children 
                               FROM nodes AS n 
-                              WHERE n.id=%s AND n.course_id=%s''' % (node_id, course_id))
+                              WHERE n.id=%s AND n.course_id=%s AND n.isalive=1''' % (node_id, course_id))
         return_val = cursor.fetchone()
         if return_val is None:
             raise InvalidUsage('node_id is out of range')
@@ -144,7 +150,7 @@ class Tree(Resource):
         try:
             cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children 
                                   FROM nodes AS n
-                                  WHERE n.course_id = %s''' % course_id)
+                                  WHERE n.course_id = %s AND n.isalive=1''' % course_id)
             tree = {}
             tree["nodes"] = cursor.fetchall()
             tree["rootId"] = '54' #this is a HACK. we will be adding a few more endpoints to address the root

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE `nodes` (
     `contents` VARCHAR(300),
     `renderer` VARCHAR(50),
     `course_id` INTEGER,
+    `isalive` INTEGER,
     `children` TEXT
 );
 CREATE TABLE `links` (

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -7,6 +7,7 @@ CREATE TABLE `nodes` (
     `renderer` VARCHAR(50),
     `course_id` INTEGER,
     `isalive` INTEGER,
+    `isroot` INTEGER,
     `children` TEXT
 );
 CREATE TABLE `links` (

--- a/rpc_specification.md
+++ b/rpc_specification.md
@@ -96,3 +96,52 @@ Tree
     ]
 }
 ```
+
+Root
+----
+
+### Viewing the list of tree roots
+
+ - end point: `/root/get/`
+ - request: HTTP GET
+ - data (input): none
+ - return data:
+```
+[
+  {
+    "id": 3,
+    "renderer": "bar"
+  },
+  {
+    "id": 8,
+    "renderer": "foo"
+  }
+  ...
+]
+```
+
+### Setting a node to be a root
+
+ - end point: `/root/set/<id>/` where `<id>` is some integer
+ - request: HTTP POST
+ - data (input): None
+ - return data:
+```
+{
+  "message": "Successfully labeled node as a root.",
+  "id": "1"
+}
+```
+
+### Setting a node to no longer be a root (deletion)
+
+ - end point: `/root/delete/<id>/` where `<id>` is some integer
+ - request: HTTP POST
+ - data (input): None
+ - return data:
+```
+{
+  "message": "Successfully removed root label.",
+  "id": "1"
+}
+```

--- a/rpc_specification.md
+++ b/rpc_specification.md
@@ -13,7 +13,7 @@ Nodes
 
 ### Adding a node
 
- - end point: `/node/add/`
+ - end point: `/<course_id>/node/add/`, where `<course_id>` is some integer
  - request: HTTP POST
  - data (input):
 ```
@@ -33,7 +33,8 @@ Nodes
 
 ### Accessing a node
 
- - end point: `/node/get/<id>/` where `<id>` is some integer
+ - end point: `/<course_id>/node/get/<id>/` where `<course_id>` and `<id>` are
+   some integers
  - request: HTTP GET
  - data (input): none
  - return data:
@@ -50,7 +51,8 @@ Nodes
 
 ### Deleting a node
 
- - end point: `/node/delete/<id>/` where `<id>` is some integer
+ - end point: `/<course_id>/node/delete/<id>/` where `<course_id>` and `<id>`
+   are some integers
  - request: HTTP POST
  - data (input): None
  - return data:
@@ -77,7 +79,7 @@ Tree
 
 ### Accessing all nodes (aka the tree)
 
- - end point: `/tree/`
+ - end point: `/<course_id>/tree/`, where `<course_id>` is some integer
  - request: HTTP GET
  - data (input): none
  - return data:
@@ -102,7 +104,7 @@ Root
 
 ### Viewing the list of tree roots
 
- - end point: `/root/get/`
+ - end point: `/<course_id>/root/get/`, where `<course_id>` is some integer
  - request: HTTP GET
  - data (input): none
  - return data:
@@ -122,7 +124,7 @@ Root
 
 ### Setting a node to be a root
 
- - end point: `/root/set/<id>/` where `<id>` is some integer
+ - end point: `/<course_id>/root/set/<id>/` where `<id>` is some integer
  - request: HTTP POST
  - data (input): None
  - return data:
@@ -135,7 +137,8 @@ Root
 
 ### Setting a node to no longer be a root (deletion)
 
- - end point: `/root/delete/<id>/` where `<id>` is some integer
+ - end point: `/<course_id>/root/delete/<id>/` where `<course_id>` and `<id>`
+   are some integers
  - request: HTTP POST
  - data (input): None
  - return data:

--- a/rpc_specification.md
+++ b/rpc_specification.md
@@ -48,22 +48,15 @@ Nodes
  - No two nodes can have the same ID
  - If you request a non-existent node, you get an exception
 
-### Editing/Updating a node
+### Deleting a node
 
- - end point: `/node/update/<id>/` where `<id>` is some integer
+ - end point: `/node/delete/<id>/` where `<id>` is some integer
  - request: HTTP POST
- - data (input):
-```
-{
-  "contents": "new contents",
-  "renderer": "new renderer",
-  "children": "{ 'foo': '1', 'bar': '2', ... }"
-}
-```
+ - data (input): None
  - return data:
 ```
 {
-  "message": "Node was successfully updated",
+  "message": "Node was successfully deleted.",
   "id": "1"
 }
 ```


### PR DESCRIPTION
So this breaks down into two changes:
### Node deletion

Nodes can now be "deleted" from the database by setting the `isalive` field to `0`. This will also allow for easy retrieval of nodes later on if we decide that we want to resurrect them.
### Roots

The database will now maintain a list of nodes which can be considered valid "roots." The frontend should query for a list of roots and, from there, choose a root from which to render the tree (provided by `/tree/`). This solves two issues:
1. We no longer need to hardcode a node to be the root (which is bad). Now this can be decided dynamically during runtime, which is what we want.
2. Flexibility: our frontend can now choose/set multiple different roots, which will allow different renderings of the graph structure in the web interface.

The course administrator will be able to "set" a node to be a root (which internally sets the `isroot` field). The frontend should, upon startup, request a list of valid roots (with the GET request) and, from there, choose a node.

The course administrator can of course change his/her mind about if something is a root, and "unset" it (with the `delete` URL). This operation doesn't delete the node, it just changes the `isroot` value.
