### PR TITLE
Adding Piazza support along with miscellaneous changes

### DIFF
--- a/backend/addSampleData.py
+++ b/backend/addSampleData.py
@@ -24,6 +24,8 @@ def get_node(node_id):
     node_id = str(node_id)
     full_url = os.path.join(URL, 'node/get', node_id, '')
     ret = get(full_url)
+    if ret.status_code != 200:
+        raise ValueError('Unable to get node')
     return ret
 
 def update_node(node_id, contents='', renderer='', children=''):

--- a/backend/addSampleData.py
+++ b/backend/addSampleData.py
@@ -17,6 +17,8 @@ def create_node(contents='foo', renderer='bar'):
     """Uses the backend API to create a node"""
     node_value = {'contents': contents, 'renderer': renderer}
     ret = post(os.path.join(URL, 'node/add/'), data=node_value)
+    if ret.status_code != 200:
+        raise ValueError('Unable to create node')
     return ret
 
 def get_node(node_id):
@@ -25,7 +27,7 @@ def get_node(node_id):
     full_url = os.path.join(URL, 'node/get', node_id, '')
     ret = get(full_url)
     if ret.status_code != 200:
-        raise ValueError('Unable to get node')
+        raise ValueError('Unable to access node %s' % node_id)
     return ret
 
 def update_node(node_id, contents='', renderer='', children=''):
@@ -40,18 +42,24 @@ def update_node(node_id, contents='', renderer='', children=''):
         children = old_node['children']
     node_value = {'contents': contents, 'renderer': renderer, 'children': children}
     ret = post(os.path.join(URL, 'node/update', node_id, ''), data=node_value)
+    if ret.status_code != 200:
+        raise ValueError('Unable to update node %s' % node_id)
     return ret
 
 def delete_node(node_id):
     """Uses the backend API to delete a node that already exists"""
     node_id = str(node_id)
     ret = post(os.path.join(URL, 'node/delete', node_id, ''), data={})
+    if ret.status_code != 200:
+        raise ValueError('Unable to delete node %s' % node_id)
     return ret
 
 def add_root(root_id):
     """Uses the backend API to add a root to the tree"""
     root_id = str(root_id)
     ret = post(os.path.join(URL, 'root/set', root_id, ''), data={})
+    if ret.status_code != 200:
+        raise ValueError('Unable to add root %s' % root_id)
     return ret
 
 ## @private

--- a/backend/addSampleData.py
+++ b/backend/addSampleData.py
@@ -46,6 +46,12 @@ def delete_node(node_id):
     ret = post(os.path.join(URL, 'node/delete', node_id, ''), data={})
     return ret
 
+def add_root(root_id):
+    """Uses the backend API to add a root to the tree"""
+    root_id = str(root_id)
+    ret = post(os.path.join(URL, 'root/set', root_id, ''), data={})
+    return ret
+
 ## @private
 def node_compare(node1, node2):
     id1 = int(node1['id'])
@@ -73,3 +79,6 @@ if __name__ == '__main__':
         myid = int(node['id'])
         mychildren = json.dumps(node['children'])
         print update_node(myid, children=mychildren).json()
+
+    # Set the root to be node 54
+    print add_root(54).json()

--- a/backend/cdApp.py
+++ b/backend/cdApp.py
@@ -80,8 +80,8 @@ class Node(Resource):
                 contents = request.form['contents']
                 renderer = request.form['renderer']
                 children = request.form['children']
-                g.db.execute('''UPDATE nodes 
-                                SET contents=(?),renderer=(?),children=(?) 
+                g.db.execute('''UPDATE nodes
+                                SET contents=(?),renderer=(?),children=(?)
                                 WHERE id=%s AND course_id=%s AND isalive=1''' % (node_id, course_id),
                              [contents, renderer, children])
             except Exception as e:
@@ -90,8 +90,8 @@ class Node(Resource):
             g.db.commit()
             return jsonify(message='Node was successfully updated.', id=node_id)
         elif operation == 'delete':
-            g.db.execute('''UPDATE nodes 
-                            SET isalive=0 
+            g.db.execute('''UPDATE nodes
+                            SET isalive=0
                             WHERE id=%s AND course_id=%s''' % (node_id, course_id))
             g.db.commit()
             return jsonify(message='Node was successfully deleted.', id=node_id)
@@ -108,8 +108,8 @@ class Node(Resource):
             raise InvalidUsage('Unknown operation')
 
         node_id = str(node_id)
-        cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children 
-                              FROM nodes AS n 
+        cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children
+                              FROM nodes AS n
                               WHERE n.id=%s AND n.course_id=%s AND n.isalive=1''' % (node_id, course_id))
         return_val = cursor.fetchone()
         if return_val is None:
@@ -133,8 +133,8 @@ class Node(Resource):
     #     """
     #     # TODO(nfischer): Fix this to work with multi-digit node_ids (use %s
     #     # formatting)
-    #     g.db.execute('''UPDATE children 
-    #                     SET children=(?) 
+    #     g.db.execute('''UPDATE children
+    #                     SET children=(?)
     #                     WHERE parent_id=(?)''', [request.form['children'], node_id])
     #     g.db.commit()
     #     return jsonify(message='Children were successfully updated.', id=node_id)
@@ -148,7 +148,7 @@ class Tree(Resource):
         rootId is hard coded right now. Need clarification on that
         """
         try:
-            cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children 
+            cursor = g.db.execute('''SELECT n.id, n.contents, n.renderer, n.children
                                   FROM nodes AS n
                                   WHERE n.course_id = %s AND n.isalive=1''' % course_id)
             tree = {}
@@ -161,14 +161,14 @@ class Tree(Resource):
 class Root(Resource):
     def post(self, course_id, operation, root_id):
         if operation == 'set':
-            g.db.execute('''UPDATE nodes 
-                            SET isroot=1 
+            g.db.execute('''UPDATE nodes
+                            SET isroot=1
                             WHERE id=%s AND course_id=%s AND isalive=1''' % (root_id, course_id))
             g.db.commit()
             return jsonify(message='Successfully labeled node as a root.', id=root_id)
         elif operation == 'delete':
-            g.db.execute('''UPDATE nodes 
-                            SET isroot=0 
+            g.db.execute('''UPDATE nodes
+                            SET isroot=0
                             WHERE id=%s AND course_id=%s AND isalive=1''' % (root_id, course_id))
             g.db.commit()
             return jsonify(message='Successfully removed root label.', id=root_id)
@@ -179,7 +179,7 @@ class Root(Resource):
         if operation != 'get':
             raise InvalidUsage('Unknown operation type')
 
-        cursor = g.db.execute('''SELECT id, renderer 
+        cursor = g.db.execute('''SELECT id, renderer
                               FROM nodes
                               WHERE course_id = %s AND isalive=1 AND isroot=1''' % course_id)
         root_list = cursor.fetchall()

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -1,6 +1,7 @@
 drop table if exists nodes;
 drop table if exists children;
 drop table if exists links;
+drop table if exists courses;
 CREATE TABLE `nodes` (
     `id` INTEGER PRIMARY KEY AUTOINCREMENT,
     `contents` VARCHAR(300),
@@ -25,5 +26,9 @@ CREATE TABLE `children` (
     FOREIGN KEY(`parent_id`) REFERENCES nodes ( 'id' )
 );
 
+CREATE TABLE `courses` (
+    `course_id` INTEGER PRIMARY KEY NOT NULL,
+    `piazza_cid` VARCHAR(100) NOT NULL
+);
 
 PRAGMA foreign_keys = ON;

--- a/rpc_specification.md
+++ b/rpc_specification.md
@@ -148,3 +148,60 @@ Root
   "id": "1"
 }
 ```
+
+Piazza Integration
+------------------
+
+### Adding a Piazza course ID
+
+ - end point: `/<course_id>/course/setpiazza/`, where `<course_id>` is some integer
+ - request: HTTP POST
+ - data (input):
+```
+{
+  "piazza_cid": "123456789"
+}
+```
+ - return data:
+```
+{
+  "message": "Successfully added piazza ID for course",
+  "course_id": "1"
+}
+```
+ - This will fail if the course already has a Piazza ID (because we don't want
+   to overwrite it unless we **really** mean to)
+
+### Restting a Piazza course ID
+
+ - end point: `/<course_id>/course/resetpiazza/` where `<course_id>` is an integer
+ - request: HTTP POST
+ - data (input):
+```
+{
+  "piazza_cid": "123456789"
+}
+```
+ - return data:
+```
+{
+  "message": "Successfully added piazza ID for course",
+  "course_id": "1"
+}
+```
+ - This will fail if the course ID is not already present (by design to prevent
+   this from being accidentally changed)
+
+### Accessing
+
+ - end point: `/<course_id>/course/getpiazza/` where `<course_id>` is some integer
+ - request: HTTP GET
+ - data (input): None
+ - return data:
+```
+{
+  "message": "Returning piazza ID for course",
+  "course_id": "1",
+  "piazza_cid": "123456789"
+}
+```


### PR DESCRIPTION
### Piazza

This now stores piazza IDs and has an API for accessing/changing these IDs. This should be the first step to having Piazza integration in our project.
### SQL updates

I cleaned up the SQL queries in the python. This should only be a stylistic change. I removed trailing whitespace in the process and saw no errors (so if you see errors on your system, please tell me).
### addSampleData script

This was a little overdue, but the `addSampleData.py` script will set the root list to be node 54 (so we won't need to hardcode 54 in `cdApp.py` once the frontend code relies on the `Root` API instead of the `rootId` field in the "get tree" request). This does not yet change any of the actual code, but just changes our test harness to set the root of the tree in a way similar to how it will be set in the real implementation).
