### PR TITLE
Support Python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
+  - "3.6"
 
 # command to install dependencies
 install:

--- a/backend/cdApp.py
+++ b/backend/cdApp.py
@@ -92,9 +92,9 @@ class Node(Resource):
                 # children, content and renderer each for each update
                 node_id = str(node_id)
 
-                contents = request.form['contents'] if request.form.has_key('contents') else None
-                renderer = request.form['renderer'] if request.form.has_key('renderer') else None
-                children = request.form['children'] if request.form.has_key('children') else None
+                contents = request.form.get('contents')
+                renderer = request.form.get('renderer')
+                children = request.form.get('children')
                 data = []
                 sql_list = []
 
@@ -129,7 +129,7 @@ class Node(Resource):
             except InvalidUsage:
                 raise # reraise this exception so it's public-facing
             except Exception as e:
-                print str(e)
+                print(str(e))
                 raise InvalidUsage('Internal error', status_code=500)
             return jsonify(message='Node was successfully updated.', id=node_id)
 
@@ -255,7 +255,7 @@ class Course(Resource):
                 return jsonify(message='Successfully added piazza ID for course',
                                course_id=course_id)
             except Exception as e:
-                print str(e)
+                print(str(e))
                 raise InvalidUsage('Cannot set more than once')
 
         elif operation == 'resetpiazza':

--- a/backend/testCRUD.py
+++ b/backend/testCRUD.py
@@ -357,13 +357,13 @@ class TreeTests(unittest.TestCase):
         node_id = int(jd['id'])
         node_list.append(node_id)
         # Check that nodes are in increasing order
-        self.assertTrue(sorted(node_list))
+        self.assertEqual(node_list, sorted(node_list))
         # Get the tree
         res = get(self.url + '/{0}/tree/'.format(self.cid))
         self.assertEqual(res.status_code, 200)
         tree_nodes = res.json()['nodes']
         self.assertEqual(type(tree_nodes), type(node_list))
-        tree_nodes.sort()
+        tree_nodes.sort(key=lambda node: node.get('id'))
         counter = 0
         for tnode, nid in zip(tree_nodes, node_list):
             self.assertEqual(type(tnode['id']), INT_TYPE)


### PR DESCRIPTION
Minor changes to support python2 and python3 simultaneously. This adds
python3 to the Travis matrix.

This also fixes a bug I noticed in an existing test (`sorted()` returns
a sorted copy of the list, it does not check if a list is sorted).