### PR TITLE
chore: use npm ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - pip install -r requirements.txt
   - cd backend/frontend/
   - nvm install node # latest stable node version
-  - npm install
+  - npm ci
   - cd ../..
 
 # command to run tests


### PR DESCRIPTION
No change to logic, just use `npm ci` in Travis because it should be
faster.